### PR TITLE
Remove extra newline in vscode terminal

### DIFF
--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -282,5 +282,5 @@ function fish_prompt
     )
 
     echo "$line1"
-    echo "$line2 "
+    echo -n "$line2 "
 end


### PR DESCRIPTION
To fix bug of extra newline when run terminal on vscode.
Please see the screenshot.

![vscode_term](https://github.com/hastinbe/theme-kawasaki/assets/1749489/90a62935-593b-4e81-84f9-7b562805ad59)
